### PR TITLE
CI: Add maven build workflow

### DIFF
--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -1,0 +1,176 @@
+name: Build and Run Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Builder-Docker-Image:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and export
+        uses: docker/build-push-action@v4
+        with:
+          context: Builder/Ubuntu/
+          tags: ${{ vars.ROBOT_IMAGE }}:latest  
+          outputs: type=docker,dest=/tmp/${{ vars.ROBOT_IMAGE }}.tar
+      -
+        name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}   
+          path: /tmp/${{ vars.ROBOT_IMAGE }}.tar
+
+
+  aaa:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: |
+         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/aaa.git" && cd /aaa && mvn clean install'
+    
+  yangtools:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean install'  
+            
+  Integration-distribution:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean install'  
+  
+  Serviceutils:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+  
+      - name: Maven Build 
+        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/serviceutils.git" && cd /serviceutils && mvn clean install'  
+
+  odlparent:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: |
+         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean install'  
+  
+  Openflowplugin:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: |
+         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean install'  
+         
+  Ovsdb:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: |
+         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/ovsdb.git" && cd /ovsdb && mvn clean install'  


### PR DESCRIPTION
_Create a  Maven-build-workflow_
- Utilizes the Robot Docker image to perform Maven builds for various OpenDaylight projects, including:
     - 'aaa'
     - 'yangtools'
     - 'integration/distribution'
     - 'serviceutils'
     - 'odlparent'
     - 'openflowplugin'
     - 'ovsdb'
     
     [Add the value of  variable  (vars.ROBOT_IMAGE ) ,  required  for the working of workflow ]