### PR TITLE
CI: Add CSIT 1-Node Tests for OpenDaylight and Update the Maven-build-workflow variable naming 

### DIFF
--- a/.github/workflows/csit-1-node.yaml
+++ b/.github/workflows/csit-1-node.yaml
@@ -2,10 +2,17 @@ name: CSIT-1-Node-Test
 
 on:
   push:
+    # Trigger the workflow on a push event
 
 jobs:
-  daexim-csit-1-node-argon:
+  csit:
     runs-on: ubuntu-latest
+    # Run the job on an Ubuntu latest runner
+
+    strategy:
+      matrix:
+        test_suite: ["daexim", "distribution", "aaa"]
+        # Define a matrix for different test suites
 
     services:
       opendaylight:
@@ -15,137 +22,71 @@ jobs:
         ports:
           - 8181:8181
         options: --name odl-container
+        # Set up a service container for OpenDaylight
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        # Checkout the code repository
 
-      - name: ssh
+      - name: Setup Jolokia for AAA
+        if: matrix.test_suite == 'aaa'
         run: |
-          docker exec odl-container bash -c "mkdir /home/youruser/.ssh && touch /home/youruser/.ssh/authorized_keys"
-      - name: Start robot container
-        run: |
-          docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
-
-      - name: Extract id_rsa.pub from the robot container
-        id: extract_pubkey
-        run: |
-          docker exec robot cat /root/.ssh/id_rsa.pub > id_rsa.pub
-        continue-on-error: true
-
-      - name: Add public key to opendaylight container
-        run: |
-          PUB_KEY=$(cat id_rsa.pub)
-          docker exec odl-container bash -c "mkdir /home/youruser/.shh && echo \"$PUB_KEY\" >> /home/youruser/.ssh/authorized_keys"
-      - name: Delay for 30 seconds
-        run: sleep 30
-
-      - name: Run Test
-        run: |
-          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
-            cd integration-test/csit/suites/daexim && 
-            robot -L debug --variable USER_HOME:/root \
-            --variable WORKSPACE:/home/youruser \
-            -v BUNDLEFOLDER:karaf-0.18.1 \
-            -v ODL_STREAM:argon \
-            --variable DEFAULT_LINUX_PROMPT:\$ \
-            --variable ODL_SYSTEM_USER:youruser \
-            --variable ODL_SYSTEM_IP:opendaylight \
-            --variable ODL_SYSTEM_1_IP:opendaylight \
-            -v IS_KARAF_APPL:True \
-            ./010-special-export.robot 020-import-basic.robot 030-export-basic.robot 040-export-inclusions.robot '
-
-  aaa-csit-1-node-authn-all-argon:
-    runs-on: ubuntu-latest
-
-    services:
-      opendaylight:
-        image: ${{ vars.REPOSITORY }}/${{ vars.ODL_IMAGE }}
-        env:
-          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
-        ports:
-          - 8181:8181
-        options: --name odl-container
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: setup-jolokia
-        run: |
+          # Configure Jolokia for the 'aaa' test suite
           docker exec -i odl-container bash -c \
-            'echo "org.jolokia.authMode=basic" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
-             echo "org.jolokia.user=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
-             echo "org.jolokia.password=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg'
+          'echo "org.jolokia.authMode=basic" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+          echo "org.jolokia.user=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+          echo "org.jolokia.password=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg'
+
+      - name: Setup SSH
+        run: |
+          # Set up SSH in the container
+          docker exec odl-container bash -c "mkdir -p /home/youruser/.ssh && touch /home/youruser/.ssh/authorized_keys"
+
       - name: Start robot container
         run: |
-          docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
-
-      - name: Delay for 30 seconds
-        run: sleep 30
-
-      - name: Run Test
-        run: |
-          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
-            cd integration-test/csit/suites/aaa && 
-            robot -L debug --variable USER_HOME:/root \
-            --variable WORKSPACE:/home/youruser \
-            -v BUNDLEFOLDER:karaf-0.18.1 \
-            -v ODL_STREAM:argon \
-            --variable DEFAULT_LINUX_PROMPT:\$ \
-            --variable ODL_SYSTEM_USER:youruser \
-            --variable ODL_SYSTEM_IP:opendaylight \
-            --variable ODL_SYSTEM_1_IP:opendaylight \
-            -v IS_KARAF_APPL:True \
-            ./authn '
-
-  distribution-csit-1-node-userfeatures-all:
-    runs-on: ubuntu-latest
-
-    services:
-      opendaylight:
-        image: ${{ vars.REPOSITORY }}/${{ vars.ODL_IMAGE }}
-        env:
-          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
-        ports:
-          - 8181:8181
-        options: --name odl-container
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: ssh
-        run: |
-          docker exec odl-container bash -c "mkdir /home/youruser/.ssh && touch /home/youruser/.ssh/authorized_keys"
-      - name: Start robot container
-        run: |
+          # Start the robot container
           docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
 
       - name: Extract id_rsa.pub from the robot container
         id: extract_pubkey
         run: |
+          # Extract the id_rsa.pub from the robot container
           docker exec robot cat /root/.ssh/id_rsa.pub > id_rsa.pub
         continue-on-error: true
 
       - name: Add public key to opendaylight container
         run: |
+          # Add the public key to the OpenDaylight container
           PUB_KEY=$(cat id_rsa.pub)
-          docker exec odl-container bash -c "mkdir /home/youruser/.shh && echo \"$PUB_KEY\" >> /home/youruser/.ssh/authorized_keys"
+          docker exec odl-container bash -c "mkdir -p /home/youruser/.ssh && echo \"$PUB_KEY\" >> /home/youruser/.ssh/authorized_keys"
+
       - name: Delay for 30 seconds
         run: sleep 30
+        # Delay for 30 seconds
 
       - name: Run Test
         run: |
-          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
-            cd integration-test/csit/suites/distribution && 
+          # Define test_suite variable based on the matrix
+          test_suite=${{ matrix.test_suite }}
+          if [ "${{ matrix.test_suite }}" == "daexim" ]; then
+            robot_test_file="./010-special-export.robot 020-import-basic.robot 030-export-basic.robot 040-export-inclusions.robot"
+          elif [ "${{ matrix.test_suite }}" == "distribution" ]; then
+            robot_test_file="karaf_sequence_install.robot karaf_stop.robot size.robot"
+          elif [ "${{ matrix.test_suite }}" == "aaa" ]; then
+            robot_test_file="authn"           
+          fi
+          # Run robot tests in the appropriate directory
+          docker exec robot bash -c "git clone https://github.com/opendaylight/integration-test.git &&       
+            cd integration-test/csit/suites/${test_suite} && 
             robot -L debug --variable USER_HOME:/root \
-            --variable WORKSPACE:/home/youruser \
-            -v BUNDLEFOLDER:karaf-0.18.1 \
-            -v ODL_STREAM:argon \
-            --variable DEFAULT_LINUX_PROMPT:\$ \
-            --variable ODL_SYSTEM_USER:youruser \
-            --variable ODL_SYSTEM_IP:opendaylight \
-            --variable ODL_SYSTEM_1_IP:opendaylight \
-            -v IS_KARAF_APPL:True \
-            ./karaf_sequence_install.robot karaf_stop.robot size.robot'
+              --variable WORKSPACE:/home/youruser \
+              -v BUNDLEFOLDER:karaf-0.18.1 \
+              -v ODL_STREAM:argon \
+              --variable DEFAULT_LINUX_PROMPT:\\\$ \
+              --variable ODL_SYSTEM_USER:youruser \
+              --variable ODL_SYSTEM_IP:opendaylight \
+              --variable ODL_SYSTEM_1_IP:opendaylight \
+              -v IS_KARAF_APPL:True \
+              $robot_test_file"
+        # Run the Robot Framework tests

--- a/.github/workflows/csit-1-node.yaml
+++ b/.github/workflows/csit-1-node.yaml
@@ -1,0 +1,151 @@
+name: CSIT-1-Node-Test
+
+on:
+  push:
+
+jobs:
+  daexim-csit-1-node-argon:
+    runs-on: ubuntu-latest
+
+    services:
+      opendaylight:
+        image: ${{ vars.REPOSITORY }}/${{ vars.ODL_IMAGE }}
+        env:
+          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
+        ports:
+          - 8181:8181
+        options: --name odl-container
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: ssh
+        run: |
+          docker exec odl-container bash -c "mkdir /home/youruser/.ssh && touch /home/youruser/.ssh/authorized_keys"
+      - name: Start robot container
+        run: |
+          docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
+
+      - name: Extract id_rsa.pub from the robot container
+        id: extract_pubkey
+        run: |
+          docker exec robot cat /root/.ssh/id_rsa.pub > id_rsa.pub
+        continue-on-error: true
+
+      - name: Add public key to opendaylight container
+        run: |
+          PUB_KEY=$(cat id_rsa.pub)
+          docker exec odl-container bash -c "mkdir /home/youruser/.shh && echo \"$PUB_KEY\" >> /home/youruser/.ssh/authorized_keys"
+      - name: Delay for 30 seconds
+        run: sleep 30
+
+      - name: Run Test
+        run: |
+          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
+            cd integration-test/csit/suites/daexim && 
+            robot -L debug --variable USER_HOME:/root \
+            --variable WORKSPACE:/home/youruser \
+            -v BUNDLEFOLDER:karaf-0.18.1 \
+            -v ODL_STREAM:argon \
+            --variable DEFAULT_LINUX_PROMPT:\$ \
+            --variable ODL_SYSTEM_USER:youruser \
+            --variable ODL_SYSTEM_IP:opendaylight \
+            --variable ODL_SYSTEM_1_IP:opendaylight \
+            -v IS_KARAF_APPL:True \
+            ./010-special-export.robot 020-import-basic.robot 030-export-basic.robot 040-export-inclusions.robot '
+
+  aaa-csit-1-node-authn-all-argon:
+    runs-on: ubuntu-latest
+
+    services:
+      opendaylight:
+        image: ${{ vars.REPOSITORY }}/${{ vars.ODL_IMAGE }}
+        env:
+          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
+        ports:
+          - 8181:8181
+        options: --name odl-container
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup-jolokia
+        run: |
+          docker exec -i odl-container bash -c \
+            'echo "org.jolokia.authMode=basic" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+             echo "org.jolokia.user=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+             echo "org.jolokia.password=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg'
+      - name: Start robot container
+        run: |
+          docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
+
+      - name: Delay for 30 seconds
+        run: sleep 30
+
+      - name: Run Test
+        run: |
+          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
+            cd integration-test/csit/suites/aaa && 
+            robot -L debug --variable USER_HOME:/root \
+            --variable WORKSPACE:/home/youruser \
+            -v BUNDLEFOLDER:karaf-0.18.1 \
+            -v ODL_STREAM:argon \
+            --variable DEFAULT_LINUX_PROMPT:\$ \
+            --variable ODL_SYSTEM_USER:youruser \
+            --variable ODL_SYSTEM_IP:opendaylight \
+            --variable ODL_SYSTEM_1_IP:opendaylight \
+            -v IS_KARAF_APPL:True \
+            ./authn '
+
+  distribution-csit-1-node-userfeatures-all:
+    runs-on: ubuntu-latest
+
+    services:
+      opendaylight:
+        image: ${{ vars.REPOSITORY }}/${{ vars.ODL_IMAGE }}
+        env:
+          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
+        ports:
+          - 8181:8181
+        options: --name odl-container
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: ssh
+        run: |
+          docker exec odl-container bash -c "mkdir /home/youruser/.ssh && touch /home/youruser/.ssh/authorized_keys"
+      - name: Start robot container
+        run: |
+          docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
+
+      - name: Extract id_rsa.pub from the robot container
+        id: extract_pubkey
+        run: |
+          docker exec robot cat /root/.ssh/id_rsa.pub > id_rsa.pub
+        continue-on-error: true
+
+      - name: Add public key to opendaylight container
+        run: |
+          PUB_KEY=$(cat id_rsa.pub)
+          docker exec odl-container bash -c "mkdir /home/youruser/.shh && echo \"$PUB_KEY\" >> /home/youruser/.ssh/authorized_keys"
+      - name: Delay for 30 seconds
+        run: sleep 30
+
+      - name: Run Test
+        run: |
+          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
+            cd integration-test/csit/suites/distribution && 
+            robot -L debug --variable USER_HOME:/root \
+            --variable WORKSPACE:/home/youruser \
+            -v BUNDLEFOLDER:karaf-0.18.1 \
+            -v ODL_STREAM:argon \
+            --variable DEFAULT_LINUX_PROMPT:\$ \
+            --variable ODL_SYSTEM_USER:youruser \
+            --variable ODL_SYSTEM_IP:opendaylight \
+            --variable ODL_SYSTEM_1_IP:opendaylight \
+            -v IS_KARAF_APPL:True \
+            ./karaf_sequence_install.robot karaf_stop.robot size.robot'

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -1,0 +1,176 @@
+name: Build and Run Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Builder-Docker-Image:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and export
+        uses: docker/build-push-action@v4
+        with:
+          context: Builder/Ubuntu/
+          tags: ${{ vars.ROBOT_IMAGE }}:latest  
+          outputs: type=docker,dest=/tmp/${{ vars.ROBOT_IMAGE }}.tar
+      -
+        name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}   
+          path: /tmp/${{ vars.ROBOT_IMAGE }}.tar
+
+
+  aaa:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: |
+         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/aaa.git" && cd /aaa && mvn clean install'
+    
+  yangtools:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean install'  
+            
+  Integration-distribution:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean install'  
+  
+  Serviceutils:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+  
+      - name: Maven Build 
+        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/serviceutils.git" && cd /serviceutils && mvn clean install'  
+
+  odlparent:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: |
+         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean install'  
+  
+  Openflowplugin:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: |
+         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean install'  
+         
+  Ovsdb:
+    runs-on: ubuntu-latest
+    needs: Builder-Docker-Image
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.ROBOT_IMAGE }}
+          path: /tmp
+      -
+        name: Load image
+        run: |
+          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+      - name: Maven Build 
+        run: |
+         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/ovsdb.git" && cd /ovsdb && mvn clean install'  

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -9,168 +9,141 @@ jobs:
   Builder-Docker-Image:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Build and export
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and export
         uses: docker/build-push-action@v4
         with:
           context: Builder/Ubuntu/
-          tags: ${{ vars.BASE_IMAGE }}:latest  
-          outputs: type=docker,dest=/tmp/${{ vars.BASE_IMAGE }}.tar
-      -
-        name: Upload artifact
+          tags: ${{ vars.ODL_BASE_IMAGE_NAME }}:latest
+          outputs: type=docker,dest=/tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ vars.BASE_IMAGE }}   
-          path: /tmp/${{ vars.BASE_IMAGE }}.tar
-
+          name: ${{ vars.ODL_BASE_IMAGE_NAME }}
+          path: /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
 
   aaa:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Download artifact
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.BASE_IMAGE }}
+          name: ${{ vars.ODL_BASE_IMAGE_NAME }}
           path: /tmp
-      -
-        name: Load image
+      - name: Load image
         run: |
-          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
-      - name: Maven Build 
+          docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
+      - name: Maven Build
         run: |
-         docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/aaa.git" && cd /aaa && mvn clean install'
-    
+          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/aaa.git" && cd /aaa && mvn clean install'
+
   yangtools:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Download artifact
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.BASE_IMAGE }}
+          name: ${{ vars.ODL_BASE_IMAGE_NAME }}
           path: /tmp
-      -
-        name: Load image
+      - name: Load image
         run: |
-          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
-      - name: Maven Build 
-        run: docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean install'  
-            
+          docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
+      - name: Maven Build
+        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean install'
+
   integration-distribution:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Download artifact
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.BASE_IMAGE }}
+          name: ${{ vars.ODL_BASE_IMAGE_NAME }}
           path: /tmp
-      -
-        name: Load image
+      - name: Load image
         run: |
-          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
-      - name: Maven Build 
-        run: docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean install'  
-  
+          docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
+      - name: Maven Build
+        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean install'
+
   serviceutils:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Download artifact
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.BASE_IMAGE }}
+          name: ${{ vars.ODL_BASE_IMAGE_NAME }}
           path: /tmp
-      -
-        name: Load image
+      - name: Load image
         run: |
-          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
-  
-      - name: Maven Build 
-        run: docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/serviceutils.git" && cd /serviceutils && mvn clean install'  
+          docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
+      - name: Maven Build
+        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/serviceutils.git" && cd /serviceutils && mvn clean install'
 
   odlparent:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Download artifact
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.BASE_IMAGE }}
+          name: ${{ vars.ODL_BASE_IMAGE_NAME }}
           path: /tmp
-      -
-        name: Load image
+      - name: Load image
         run: |
-          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
-      - name: Maven Build 
+          docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
+      - name: Maven Build
         run: |
-         docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean install'  
-  
+          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean install'
+
   openflowplugin:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Download artifact
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.BASE_IMAGE }}
+          name: ${{ vars.ODL_BASE_IMAGE_NAME }}
           path: /tmp
-      -
-        name: Load image
+      - name: Load image
         run: |
-          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
-      - name: Maven Build 
+          docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
+      - name: Maven Build
         run: |
-         docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean install'  
-         
+          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean install'
+
   ovsdb:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Download artifact
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.BASE_IMAGE }}
+          name: ${{ vars.ODL_BASE_IMAGE_NAME }}
           path: /tmp
-      -
-        name: Load image
+      - name: Load image
         run: |
-          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
-      - name: Maven Build 
+          docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
+      - name: Maven Build
         run: |
-         docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/ovsdb.git" && cd /ovsdb && mvn clean install'  
+          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/ovsdb.git" && cd /ovsdb && mvn clean install'

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Maven Build 
         run: docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean install'  
             
-  Integration-distribution:
+  integration-distribution:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
@@ -91,7 +91,7 @@ jobs:
       - name: Maven Build 
         run: docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean install'  
   
-  Serviceutils:
+  serviceutils:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
@@ -133,7 +133,7 @@ jobs:
         run: |
          docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean install'  
   
-  Openflowplugin:
+  openflowplugin:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:
@@ -154,7 +154,7 @@ jobs:
         run: |
          docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean install'  
          
-  Ovsdb:
+  ovsdb:
     runs-on: ubuntu-latest
     needs: Builder-Docker-Image
     steps:

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -20,14 +20,14 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: Builder/Ubuntu/
-          tags: ${{ vars.ROBOT_IMAGE }}:latest  
-          outputs: type=docker,dest=/tmp/${{ vars.ROBOT_IMAGE }}.tar
+          tags: ${{ vars.BASE_IMAGE }}:latest  
+          outputs: type=docker,dest=/tmp/${{ vars.BASE_IMAGE }}.tar
       -
         name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ vars.ROBOT_IMAGE }}   
-          path: /tmp/${{ vars.ROBOT_IMAGE }}.tar
+          name: ${{ vars.BASE_IMAGE }}   
+          path: /tmp/${{ vars.BASE_IMAGE }}.tar
 
 
   aaa:
@@ -41,15 +41,15 @@ jobs:
         name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.ROBOT_IMAGE }}
+          name: ${{ vars.BASE_IMAGE }}
           path: /tmp
       -
         name: Load image
         run: |
-          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
       - name: Maven Build 
         run: |
-         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/aaa.git" && cd /aaa && mvn clean install'
+         docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/aaa.git" && cd /aaa && mvn clean install'
     
   yangtools:
     runs-on: ubuntu-latest
@@ -62,14 +62,14 @@ jobs:
         name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.ROBOT_IMAGE }}
+          name: ${{ vars.BASE_IMAGE }}
           path: /tmp
       -
         name: Load image
         run: |
-          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
       - name: Maven Build 
-        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean install'  
+        run: docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean install'  
             
   Integration-distribution:
     runs-on: ubuntu-latest
@@ -82,14 +82,14 @@ jobs:
         name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.ROBOT_IMAGE }}
+          name: ${{ vars.BASE_IMAGE }}
           path: /tmp
       -
         name: Load image
         run: |
-          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
       - name: Maven Build 
-        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean install'  
+        run: docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean install'  
   
   Serviceutils:
     runs-on: ubuntu-latest
@@ -102,15 +102,15 @@ jobs:
         name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.ROBOT_IMAGE }}
+          name: ${{ vars.BASE_IMAGE }}
           path: /tmp
       -
         name: Load image
         run: |
-          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
   
       - name: Maven Build 
-        run: docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/serviceutils.git" && cd /serviceutils && mvn clean install'  
+        run: docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/serviceutils.git" && cd /serviceutils && mvn clean install'  
 
   odlparent:
     runs-on: ubuntu-latest
@@ -123,15 +123,15 @@ jobs:
         name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.ROBOT_IMAGE }}
+          name: ${{ vars.BASE_IMAGE }}
           path: /tmp
       -
         name: Load image
         run: |
-          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
       - name: Maven Build 
         run: |
-         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean install'  
+         docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean install'  
   
   Openflowplugin:
     runs-on: ubuntu-latest
@@ -144,15 +144,15 @@ jobs:
         name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.ROBOT_IMAGE }}
+          name: ${{ vars.BASE_IMAGE }}
           path: /tmp
       -
         name: Load image
         run: |
-          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
       - name: Maven Build 
         run: |
-         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean install'  
+         docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean install'  
          
   Ovsdb:
     runs-on: ubuntu-latest
@@ -165,12 +165,12 @@ jobs:
         name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ vars.ROBOT_IMAGE }}
+          name: ${{ vars.BASE_IMAGE }}
           path: /tmp
       -
         name: Load image
         run: |
-          docker load --input /tmp/${{ vars.ROBOT_IMAGE }}.tar
+          docker load --input /tmp/${{ vars.BASE_IMAGE }}.tar
       - name: Maven Build 
         run: |
-         docker run ${{ vars.ROBOT_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/ovsdb.git" && cd /ovsdb && mvn clean install'  
+         docker run ${{ vars.BASE_IMAGE }}:latest bash -c 'git clone "https://github.com/opendaylight/ovsdb.git" && cd /ovsdb && mvn clean install'  


### PR DESCRIPTION
This commit adds GitHub Actions workflows for running CSIT (Continuous System Integration Test) 1-Node tests on an OpenDaylight instance. Three separate workflows are included:
1. daexim-csit-1-node
2. aaa-csit-1-node-authn-all
3. distribution-csit-1-node-userfeatures-all

and Update the Maven-build-workflow variable naming 