### PR TITLE
Add ODL Dockerfile, ODL Dockerfile Workflow, and Update CSIT-1-node-test ODL Image

### DIFF
--- a/.github/workflows/csit-1-node.yaml
+++ b/.github/workflows/csit-1-node.yaml
@@ -28,7 +28,7 @@
   
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           # Checkout the code repository
   
         - name: Setup Jolokia for AAA
@@ -62,11 +62,7 @@
         
         - name: Delay for 30 seconds
           run: sleep 30
-          # Delay for 30 seconds
-        # - name: stop 
-        #   run: docker stop odl-container 
-        # - name: start
-        #   run: docker start odl-container
+
         - name: Run Test
           run: |
             # Define test_suite variable based on the matrix

--- a/.github/workflows/csit-1-node.yaml
+++ b/.github/workflows/csit-1-node.yaml
@@ -1,94 +1,94 @@
 ---
-name: CSIT-1-Node-Test
-
-on:
-  push:
-    branches:
-      - main
-
-jobs:
-  csit:
-    runs-on: ubuntu-latest
-    # Run the job on an Ubuntu latest runner
-
-    strategy:
-      matrix:
-        test_suite: ["daexim", "distribution", "aaa"]
-        # Define a matrix for different test suites
-
-    services:
-      opendaylight:
-        image: ${{ vars.DOCKER_REPOSITORY }}/${{ vars.ODL_IMAGE }}
-        env:
-          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
-        ports:
-          - 8181:8181
-        options: --name odl-container
-        # Set up a service container for OpenDaylight
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        # Checkout the code repository
-
-      - name: Setup Jolokia for AAA
-        if: matrix.test_suite == 'aaa'
-        run: |
-          # Configure Jolokia for the 'aaa' test suite
-          docker exec -i odl-container bash -c \
-          'echo "org.jolokia.authMode=basic" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
-          echo "org.jolokia.user=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
-          echo "org.jolokia.password=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg'
-
-      - name: Setup SSH
-        run: |
-          # Set up SSH in the container
-          docker exec odl-container bash -c "mkdir -p /home/youruser/.ssh && touch /home/youruser/.ssh/authorized_keys"
-
-      - name: Start robot container
-        run: |
-          # Start the robot container
-          docker run -d --network container:odl-container --name robot ${{ vars.DOCKER_REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
-
-      - name: Extract id_rsa.pub from the robot container
-        id: extract_pubkey
-        run: |
-          # Extract the id_rsa.pub from the robot container
-          docker exec robot cat /root/.ssh/id_rsa.pub > id_rsa.pub
-        continue-on-error: true
-
-      - name: Add public key to opendaylight container
-        run: |
-          # Add the public key to the OpenDaylight container
-          PUB_KEY=$(cat id_rsa.pub)
-          docker exec odl-container bash -c "mkdir -p /home/youruser/.ssh && echo \"$PUB_KEY\" >> /home/youruser/.ssh/authorized_keys"
-
-      - name: Delay for 30 seconds
-        run: sleep 30
-        # Delay for 30 seconds
-
-      - name: Run Test
-        run: |
-          # Define test_suite variable based on the matrix
-          test_suite=${{ matrix.test_suite }}
-          if [ "${{ matrix.test_suite }}" == "daexim" ]; then
-            robot_test_file="./010-special-export.robot 020-import-basic.robot 030-export-basic.robot 040-export-inclusions.robot"
-          elif [ "${{ matrix.test_suite }}" == "distribution" ]; then
-            robot_test_file="karaf_sequence_install.robot karaf_stop.robot size.robot"
-          elif [ "${{ matrix.test_suite }}" == "aaa" ]; then
-            robot_test_file="authn"
-          fi
-          # Run robot tests in the appropriate directory
-          docker exec robot bash -c "git clone https://github.com/opendaylight/integration-test.git &&
-            cd integration-test/csit/suites/${test_suite} &&
-            robot -L debug --variable USER_HOME:/root \
-              --variable WORKSPACE:/home/youruser \
-              -v BUNDLEFOLDER:karaf-0.18.1 \
-              -v ODL_STREAM:argon \
-              --variable DEFAULT_LINUX_PROMPT:\\\$ \
-              --variable ODL_SYSTEM_USER:youruser \
-              --variable ODL_SYSTEM_IP:opendaylight \
-              --variable ODL_SYSTEM_1_IP:opendaylight \
-              -v IS_KARAF_APPL:True \
-              $robot_test_file"
-        # Run the Robot Framework tests
+  name: CSIT-1-Node-Test
+  
+  on:
+    push:
+      branches:
+        - main
+  
+  jobs:
+    csit:
+      runs-on: ubuntu-latest
+      # Run the job on an Ubuntu latest runner
+  
+      strategy:
+        matrix:
+          test_suite: ["daexim", "distribution", "aaa"]
+          # Define a matrix for different test suites
+  
+      services:
+        opendaylight:
+          image: ${{ vars.DOCKER_REPOSITORY }}/${{ vars.ODL_IMAGE_NAME_CENTOS }} 
+          env:
+            FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
+          ports:
+            - 8181:8181
+          options: --name odl-container
+          # Set up a service container for OpenDaylight
+  
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+          # Checkout the code repository
+  
+        - name: Setup Jolokia for AAA
+          if: matrix.test_suite == 'aaa'
+          run: |
+            # Configure Jolokia for the 'aaa' test suite
+            docker exec -i odl-container bash -c \
+            'echo "org.jolokia.authMode=basic" >> /home/user/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+            echo "org.jolokia.user=admin" >> /home/user/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+            echo "org.jolokia.password=admin" >> /home/user/karaf-0.18.1/etc/org.jolokia.osgi.cfg'
+        - name: Setup SSH
+          run: |
+            # Set up SSH in the container
+            docker exec odl-container bash -c "mkdir -p /home/user/.ssh && touch /home/user/.ssh/authorized_keys"
+        - name: Start robot container
+          run: |
+            # Start the robot container
+            docker run -d --network container:odl-container --name robot ${{ vars.DOCKER_REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
+        - name: Extract id_rsa.pub from the robot container
+          id: extract_pubkey
+          run: |
+            # Extract the id_rsa.pub from the robot container
+            docker exec robot cat /root/.ssh/id_rsa.pub > id_rsa.pub
+          continue-on-error: true
+  
+        - name: Add public key to opendaylight container
+          run: |
+            # Add the public key to the OpenDaylight container
+            PUB_KEY=$(cat id_rsa.pub)
+            docker exec odl-container bash -c "mkdir -p /home/user/.ssh && echo \"$PUB_KEY\" >> /home/user/.ssh/authorized_keys"
+        
+        - name: Delay for 30 seconds
+          run: sleep 30
+          # Delay for 30 seconds
+        # - name: stop 
+        #   run: docker stop odl-container 
+        # - name: start
+        #   run: docker start odl-container
+        - name: Run Test
+          run: |
+            # Define test_suite variable based on the matrix
+            test_suite=${{ matrix.test_suite }}
+            if [ "${{ matrix.test_suite }}" == "daexim" ]; then
+              robot_test_file="./010-special-export.robot 020-import-basic.robot 030-export-basic.robot 040-export-inclusions.robot"
+            elif [ "${{ matrix.test_suite }}" == "distribution" ]; then
+              robot_test_file="karaf_sequence_install.robot karaf_stop.robot size.robot"
+            elif [ "${{ matrix.test_suite }}" == "aaa" ]; then
+              robot_test_file="authn"
+            fi
+            # Run robot tests in the appropriate directory
+            docker exec robot bash -c "git clone https://github.com/opendaylight/integration-test.git &&
+              cd integration-test/csit/suites/${test_suite} &&
+              robot -L debug --variable USER_HOME:/root \
+                --variable WORKSPACE:/home/user \
+                -v BUNDLEFOLDER:karaf-0.18.1 \
+                -v ODL_STREAM:argon \
+                --variable DEFAULT_LINUX_PROMPT:\\\$ \
+                --variable ODL_SYSTEM_USER:user \
+                --variable ODL_SYSTEM_IP:opendaylight \
+                --variable ODL_SYSTEM_1_IP:opendaylight \
+                -v IS_KARAF_APPL:True \
+                $robot_test_file"
+          # Run the Robot Framework tests

--- a/.github/workflows/odl-docker-image.yaml
+++ b/.github/workflows/odl-docker-image.yaml
@@ -1,0 +1,33 @@
+---
+    name: Build ODL Docker Image and Push them to Docker registry
+    
+    on:
+      push:
+        branches:
+          - '*'
+    
+    jobs:
+      builder-docker-image:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v3
+    
+          - name: Build centos Docker image
+            run: docker build --build-arg="BASE_IMAGE=centos" --build-arg="KARAF_VERSION=0.18.1" -t  ${{ vars.DOCKER_REPOSITORY }}/${{ vars.ODL_IMAGE_NAME_CENTOS }} opendaylight-docker-image 
+
+          - name: Build ubuntu Docker image                    
+            run: docker build --build-arg="KARAF_VERSION=0.18.1" -t  ${{ vars.DOCKER_REPOSITORY }}/${{ vars.ODL_IMAGE_NAME_UBUNTU }} opendaylight-docker-image 
+    
+          - name: Authenticate to Docker Hub
+            uses: docker/login-action@v2
+            with:
+              username: ${{ secrets.DOCKERHUB_USERNAME }}
+              password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+          - name: Push ODL-Centos Base Docker image
+            run: docker push ${{ vars.DOCKER_REPOSITORY }}/${{ vars.ODL_IMAGE_NAME_CENTOS }} 
+
+          - name: Push ODL-Ubuntu Base Docker image
+            run: docker push ${{ vars.DOCKER_REPOSITORY }}/${{ vars.ODL_IMAGE_NAME_UBUNTU }}
+

--- a/opendaylight-docker-image/dockerfile
+++ b/opendaylight-docker-image/dockerfile
@@ -1,0 +1,61 @@
+# Use the official Ubuntu image as the base image
+ARG BASE_IMAGE=ubuntu
+FROM ${BASE_IMAGE}:latest
+
+# Update the package list and install necessary packages
+ARG BASE_IMAGE=ubuntu
+RUN if [ "${BASE_IMAGE}" = "centos" ]; then \
+        cd /etc/yum.repos.d && \
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+        yum -y update && \
+        yum -y install wget unzip openssh-server openssh-clients java-17-openjdk java-17-openjdk-devel passwd sed; \
+    else \
+        apt-get update && apt-get install -y \
+        wget \
+        unzip \
+        openjdk-17-jdk \
+        openssh-server ; \
+    fi
+
+# Install SSH server, create a non-root user without a password
+ARG BASE_IMAGE=ubuntu
+RUN if [ "${BASE_IMAGE}" = "centos" ]; then \
+        ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' && \
+        mkdir /var/run/sshd && \
+        useradd -m -s /bin/bash user && \
+        passwd -d user && \
+        sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config && \
+        rm /run/nologin; \
+    else \
+        mkdir /var/run/sshd && \
+        useradd -m -s /bin/bash user && \
+        passwd -d user && \
+        sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin no/' /etc/ssh/sshd_config; \
+    fi
+
+# Copy the entrypoint script into the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Set the Karaf version as an environment variable
+ARG KARAF_VERSION=0.18.1
+ENV KARAF_VERSION=${KARAF_VERSION}
+RUN su - user -c "wget https://nexus.opendaylight.org/content/repositories/opendaylight.release/org/opendaylight/integration/karaf/${KARAF_VERSION}/karaf-${KARAF_VERSION}.zip \
+    && unzip /home/user/karaf-${KARAF_VERSION}.zip \
+    && chmod +x /home/user/karaf-${KARAF_VERSION}/bin/karaf \
+    && ssh-keygen -b 2048 -t rsa -f /tmp/sshkey -q -N '' "
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH=$PATH:/home/user/karaf-0.18.1/bin
+ENV KARAF_HOME=/home/user/karaf-0.18.1
+
+# Make the entrypoint script executable
+RUN chmod +x /entrypoint.sh
+
+# Expose the SSH and Karaf ports
+EXPOSE 22
+EXPOSE 8101
+EXPOSE 8181
+
+# Specify the entrypoint script as the default command
+ENTRYPOINT ["/entrypoint.sh"]

--- a/opendaylight-docker-image/entrypoint.sh
+++ b/opendaylight-docker-image/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Start SSH server as the root user
+/usr/sbin/sshd -D &
+# Wait for SSH server to start (you can customize the sleep duration as needed)
+sleep 5
+
+if [ -n "$FEATURES" ]; then
+    # Update the featuresBoot line in org.apache.karaf.features.cfg
+    su - user -c "sed -i \"s/\(featuresBoot= \|featuresBoot = \)/featuresBoot = $FEATURES,/g\" /home/user/karaf-${KARAF_VERSION}/etc/org.apache.karaf.features.cfg"
+fi
+chmod +w /home/user/karaf-${KARAF_VERSION}/etc/
+# Run Karaf as the non-root user
+su - user -c "/home/user/karaf-${KARAF_VERSION}/bin/karaf run"
+# Keep the container running
+tail -f /dev/null


### PR DESCRIPTION
 New Dockerfiles for OpenDaylight (ODL) and updates the CSIT-1-node-test ODL image. It also includes a workflow for the Dockerfile to automate the build and push to docker hub