### PR TITLE
 Reusable Workflows f csit-1-node test and Improve Workflows naming

### DIFF
--- a/.github/action/composite-csit-1-node/action.yaml
+++ b/.github/action/composite-csit-1-node/action.yaml
@@ -1,0 +1,41 @@
+name: CSIT-1-Node-Test-Composed
+inputs:
+  project_name:
+    description: "repository name"
+    required: true
+  DOCKER_REPOSITORY:
+    description: "image repository name"
+    required: true
+  ROBOT_IMAGE:
+    description: "image name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      # Checkout the code repository
+
+    - name: Setup Jolokia for AAA
+      if: ${{ inputs.project_name == 'aaa' }}
+      run: |
+        # Configure Jolokia for the 'aaa' test suite
+        docker exec -i odl-container bash -c \
+          'echo "org.jolokia.authMode=basic" >> /home/user/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+          echo "org.jolokia.user=admin" >> /home/user/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+          echo "org.jolokia.password=admin" >> /home/user/karaf-0.18.1/etc/org.jolokia.osgi.cfg'
+      shell: bash
+    - name: Robot Setup
+      uses: ayushishu/releng-docker/.github/action/ssh-setup-action@ayush
+      with:
+        docker_repository: ${{ inputs.DOCKER_REPOSITORY }}
+        robot_image: ${{ inputs.ROBOT_IMAGE }}
+
+    - name: Delay for 10 seconds
+      run: sleep 10
+      shell: bash
+    - name: Run Test
+      uses: ayushishu/releng-docker/.github/action/robot-test-action@ayush
+      with:
+        test_suite: ${{ inputs.project_name }}

--- a/.github/action/robot-test-action/action.yaml
+++ b/.github/action/robot-test-action/action.yaml
@@ -1,0 +1,33 @@
+# File: run_test.yaml
+name: "run-robot-test"
+inputs:
+  test_suite:
+    description: "test_suite"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      run: |
+        test_suite=${{ inputs.test_suite }}
+        if [ "${test_suite}" == "daexim" ]; then
+          robot_test_file="./010-special-export.robot 020-import-basic.robot 030-export-basic.robot 040-export-inclusions.robot"
+        elif [ "${test_suite}" == "distribution" ]; then
+          robot_test_file="karaf_sequence_install.robot karaf_stop.robot size.robot"
+        elif [ "${test_suite}" == "aaa" ]; then
+          robot_test_file="authn"
+        fi
+        docker exec robot bash -c "git clone https://github.com/opendaylight/integration-test.git &&
+          cd integration-test/csit/suites/${test_suite} &&
+          robot -L debug --variable USER_HOME:/root \
+            --variable WORKSPACE:/home/user \
+            -v BUNDLEFOLDER:karaf-0.18.1 \
+            -v ODL_STREAM:argon \
+            --variable DEFAULT_LINUX_PROMPT:\\\$ \
+            --variable ODL_SYSTEM_USER:user \
+            --variable ODL_SYSTEM_IP:opendaylight \
+            --variable ODL_SYSTEM_1_IP:opendaylight \
+            -v IS_KARAF_APPL:True \
+            $robot_test_file"
+      shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build Ubuntu/CentOS Docker Image and Push them to Docker registry
+name: Build Robot-Docker-Image and Builder-Docker-image Push them to Docker registry
 
 on:
   push:

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -42,7 +42,7 @@ jobs:
           docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
       - name: Maven Build
         run: |
-          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/aaa.git" && cd /aaa && mvn clean deploy'
+          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/aaa.git" && cd /aaa && mvn clean install'
 
   yangtools:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         run: |
           docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
       - name: Maven Build
-        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean deploy'
+        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/yangtools.git" && cd /yangtools && mvn clean install'
 
   integration-distribution:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
         run: |
           docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
       - name: Maven Build
-        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean deploy'
+        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://git.opendaylight.org/gerrit/integration/distribution" && cd /distribution && mvn clean install'
 
   serviceutils:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
         run: |
           docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
       - name: Maven Build
-        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/serviceutils.git" && cd /serviceutils && mvn clean deploy'
+        run: docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/serviceutils.git" && cd /serviceutils && mvn clean install'
 
   odlparent:
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
           docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
       - name: Maven Build
         run: |
-          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean deploy'
+          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/odlparent.git" && cd /odlparent && mvn clean install'
 
   openflowplugin:
     runs-on: ubuntu-latest
@@ -129,7 +129,7 @@ jobs:
           docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
       - name: Maven Build
         run: |
-          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean deploy'
+          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/openflowplugin.git" && cd /openflowplugin && mvn clean install'
 
   ovsdb:
     runs-on: ubuntu-latest
@@ -147,4 +147,4 @@ jobs:
           docker load --input /tmp/${{ vars.ODL_BASE_IMAGE_NAME }}.tar
       - name: Maven Build
         run: |
-          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/ovsdb.git" && cd /ovsdb && mvn clean deploy'
+          docker run ${{ vars.ODL_BASE_IMAGE_NAME }}:latest bash -c 'git clone "https://github.com/opendaylight/ovsdb.git" && cd /ovsdb && mvn clean install'

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build and Run Docker Image
+name: Maven-build-Job
 
 on:
   push:

--- a/.github/workflows/odl-docker-image.yaml
+++ b/.github/workflows/odl-docker-image.yaml
@@ -1,5 +1,5 @@
 ---
-    name: Build ODL Docker Image and Push them to Docker registry
+    name: ODL Docker Image - Build and Push them to Docker registry
     
     on:
       push:


### PR DESCRIPTION

**Creation of Reusable Workflows for csit-1-node Test:**
     - `.github/action/composite-csit-1-node/` to host composite actions specific to csit-1-node testing.
     - `.github/action/robot-test-action/` to store actions related to robot testing.
     
**Workflow Naming Enhancement:**
   - Improved the naming conventions of existing workflows for better clarity and consistency.